### PR TITLE
feat: add SQLAlchemy setup with env config

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,20 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+import os
+
+# I get these values from the environment variables
+# set in the docker-compose file
+db_user = os.environ.get("POSTGRES_USER")
+db_password = os.environ.get("POSTGRES_PASSWORD")
+db_name = os.environ.get("POSTGRES_DB")
+
+SQLALCHEMY_DATABASE_URL = (
+    f"postgresql://{db_user}:{db_password}@postgres:5432/{db_name}"
+)
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,15 +1,11 @@
-from typing import Union
-
+from database import engine
 from fastapi import FastAPI
+from database import Base
+
+# This needs to be imported before we call create on Base.metadata
+# because it registers the models with SQLAlchemy
+import models
 
 app = FastAPI()
 
-
-@app.get("/")
-def read_root():
-    return {"Hello": "World"}
-
-
-@app.get("/items/{item_id}")
-def read_item(item_id: int, q: Union[str, None] = None):
-    return {"item_id": item_id, "q": q}
+Base.metadata.create_all(bind=engine)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,1 @@
+from .user import User

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,16 @@
+from database import Base
+from sqlalchemy import Column, Integer, String, Boolean
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True)
+    username = Column(String, unique=True)
+    first_name = Column(String)
+    last_name = Column(String)
+    hashed_password = Column(String)
+    is_active = Column(Boolean, default=True)
+    role = Column(String)
+    phone_number = Column(String)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ h11==0.16.0
 idna==3.10
 Mako==1.3.10
 MarkupSafe==3.0.2
+psycopg2-binary==2.9.10
 pydantic==2.11.7
 pydantic_core==2.33.2
 sniffio==1.3.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - postgres
     env_file:
       - .env.example
-    # this is unnecessary for this database container (but for development sake just in case)
+    # this is unnecessary for this backend container (but for development sake just in case)
     stdin_open: true
     tty: true
 
@@ -23,7 +23,7 @@ services:
       - /app/node_modules #if my local machine has node_modules don't overwrite node_modules inside the contianer
     ports:
       - "3000:3000"
-    # this is unnecessary for this database container (but for development sake just in case)
+    # this is unnecessary for this frontend container (but for development sake just in case)
     stdin_open: true
     tty: true
 


### PR DESCRIPTION
1. Add initial database.py with SQLAlchemy engine, session, and declarative base. 
2. Configuration is loaded from environment variables for user, password, and db name. 
3. This enables model registration and table creation for the backend service.