### PR TITLE
feat: add organization admin relationship

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import DeclarativeMeta, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
 import os
 
@@ -17,4 +17,4 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-Base = declarative_base()
+Base: DeclarativeMeta = declarative_base()

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,2 +1,2 @@
 from database import Base
-from . import User
+from . import user, organization, organization_admin

--- a/backend/models/organization.py
+++ b/backend/models/organization.py
@@ -1,4 +1,4 @@
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from . import Base
 from sqlalchemy import ForeignKey, Integer, Numeric, String, Enum
 
@@ -211,7 +211,12 @@ class Country(enum.Enum):
 
 class Organization(Base):
     __tablename__ = "organizations"
-    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+
+    user: Mapped["User"] = relationship("User", back_populates="organization")
+
     name: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
 
     status: Mapped[Status] = mapped_column(
@@ -225,3 +230,7 @@ class Organization(Base):
     api_endpoint: Mapped[str] = mapped_column(String(200), unique=True, nullable=True)
 
     country: Mapped[Country] = mapped_column(Enum(Country), nullable=False)
+
+    admins: Mapped["OrganizationAdmin"] = relationship(
+        "OrganizationAdmin", back_populates="organization"
+    )

--- a/backend/models/organization_admin.py
+++ b/backend/models/organization_admin.py
@@ -1,0 +1,19 @@
+from . import Base
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import Integer, ForeignKey
+
+
+class OrganizationAdmin(Base):
+    __tablename__ = "organization_admins"
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    user: Mapped["User"] = relationship("User", back_populates="organization_admin")
+
+    organization_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("organizations.user_id", ondelete="CASCADE"), nullable=False
+    )
+
+    organization: Mapped["Organization"] = relationship(
+        "Organization", back_populates="admins"
+    )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,16 +1,36 @@
 from . import Base
-from sqlalchemy import Column, Integer, String, Boolean
+
+
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from datetime import datetime
+from sqlalchemy import String, Integer, Enum, DateTime, func, Boolean
+import enum
+
+
+class UserRole(enum.Enum):
+    admin = "admin"
+    org = "org"
+    org_admin = "org_admin"
 
 
 class User(Base):
     __tablename__ = "users"
-
-    id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True)
-    username = Column(String, unique=True)
-    first_name = Column(String)
-    last_name = Column(String)
-    hashed_password = Column(String)
-    is_active = Column(Boolean, default=True)
-    role = Column(String)
-    phone_number = Column(String)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    hashed_password: Mapped[str] = mapped_column(String(200), nullable=False)
+    role: Mapped[UserRole] = mapped_column(Enum(UserRole), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    last_access_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    # 1 to 1 relationshiop with Organization (The user may be an organization)
+    organization: Mapped["Organization"] = relationship(
+        "Organization", back_populates="user", uselist=False
+    )
+    organization_admin: Mapped["OrganizationAdmin"] = relationship(
+        "OrganizationAdmin", back_populates="user", uselist=False
+    )


### PR DESCRIPTION
Refactored Organization model to include a relationship with the new OrganizationAdmin model. Updated user_id to be the primary key and added a relationship to the User model. This change supports linking organizations with their respective admins and users, improving data integrity and query capabilities.