### PR TITLE
feat(api): add nginx reverse proxy and /api prefix

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 # main.py
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 
 # This needs to be imported before we call create on Base.metadata
 # because it registers the models with SQLAlchemy
@@ -8,12 +8,16 @@ from routers import election, organization, voter, voting_process
 app = FastAPI()
 
 
-@app.get("/healthy")
+@app.get("/api/healthy")
 def health_check():
     return {"status": "Healthy"}
 
 
-app.include_router(organization.router)
-app.include_router(election.router)
-app.include_router(voter.router)
-app.include_router(voting_process.router)
+api_router = APIRouter(prefix="/api")
+
+api_router.include_router(organization.router)
+api_router.include_router(election.router)
+api_router.include_router(voter.router)
+api_router.include_router(voting_process.router)
+
+app.include_router(api_router)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,16 @@ services:
     stdin_open: true
     tty: true
 
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - frontend
+      - backend
+
 # instructs Docker Compose to create the named
 # volume postgres_data if it doesn't already exist.
 # This is because one or more services reference this volume in their configuration.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,39 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    # Set the MIME types for Nginx to use.
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Set up logging.
+    access_log  /var/log/nginx/access.log;
+    error_log   /var/log/nginx/error.log;
+
+    # The main server block.
+    server {
+        listen 80;
+
+        # Forward all requests starting with /api/ to the FastAPI service.
+        location /api/ {
+            proxy_pass http://backend:8000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # Forward all other requests to the React development server.
+        # This includes the root path ('/') and any client-side routes.
+        location / {
+            proxy_pass http://frontend:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
Introduce nginx as a reverse proxy for frontend and backend services. All backend API routes are now prefixed with /api for consistency. Update FastAPI routing to use APIRouter with /api prefix. Add nginx configuration to forward /api requests to backend and all other requests to frontend. Update docker-compose to include nginx service.